### PR TITLE
clean(github): Replace the setup-bazel action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,11 @@ jobs:
         os: ["linux"]
     steps:
       - name: Setup bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.15.0
         with:
-          version: 8.4.1
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cache

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -27,9 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.15.0
         with:
-          version: 8.4.1
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
       - name: Checkout
         uses: actions/checkout@v3
       - name: Cache
@@ -82,9 +84,11 @@ jobs:
         os: ["linux"]
     steps:
       - name: Setup bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.15.0
         with:
-          version: 8.4.1
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup bazel
-        uses: abhinavsingh/setup-bazel@v3
+        uses: bazel-contrib/setup-bazel@0.15.0
         with:
-          version: 8.4.1
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
       - name: Checkout
         uses: actions/checkout@v2
       - name: Cache

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@ module(
     version = "2.0.1",
 )
 
-bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.50.1")
 bazel_dep(name = "gazelle", version = "0.42.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "buildifier_prebuilt", version = "6.4.0")
 bazel_dep(name = "bazel_bats", version = "0.35.0")
@@ -11,7 +11,7 @@ bazel_dep(name = "rules_pkg", version = "1.0.1")
 
 # Go SDK
 
-go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.24.1")
 
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")

--- a/cmd/gotopt2/BUILD.bazel
+++ b/cmd/gotopt2/BUILD.bazel
@@ -1,7 +1,7 @@
-load("@bazel_bats//:rules.bzl", "bats_test")
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("//build:my_package_name.bzl", "name_part_from_command_line")
+load("@bazel_bats//:rules.bzl", "bats_test")
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 
 go_library(
     name = "gotopt2_lib",

--- a/pkg/opts/BUILD.bazel
+++ b/pkg/opts/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "opts",


### PR DESCRIPTION
The new setup-bazel action is the "official" action which supports bazelisk based workflows and does not require declaring a bazel version to download.