### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in eval output

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-31 - [Command Injection via Double Quotes in eval Payload]
+**Vulnerability:** Command injection was possible because `gotopt2` output strings wrapped in double quotes (e.g., `gotopt2_var="$(echo hacked)"`), which caused the host bash script using `eval` to evaluate the inner command substitution.
+**Learning:** When generating shell code intended for `eval`, double quotes are unsafe if the content includes user input, because they allow parameter expansion and command substitution.
+**Prevention:** Always wrap generated string values in single quotes, and escape internal single quotes as `'"'"'` (or similar), to ensure the string is treated purely as a literal value by the shell parser.

--- a/cmd/gotopt2/gotopt2_test.bats
+++ b/cmd/gotopt2/gotopt2_test.bats
@@ -19,7 +19,7 @@ flags:
 EOF
 )
   expected=$'# gotopt2:generated:begin
-gotopt2_foo=\"bar\"
+gotopt2_foo=\'bar\'
 # gotopt2:generated:end'
   [ "${result}" == "${expected}" ]
 }
@@ -58,7 +58,7 @@ EOF
   echo "${lines[2]}"
   [ "${status}" -eq 0 ]
   [ "${lines[0]}" == "# gotopt2:generated:begin" ]
-  [ "${lines[1]}" == "gotopt2_list__list=(\"eenie\" \"meenie\" \"minie\" \"moe\")" ]
+  [ "${lines[1]}" == "gotopt2_list__list=('eenie' 'meenie' 'minie' 'moe')" ]
   [ "${lines[2]}" == "# gotopt2:generated:end" ]
   [ "${#lines[@]}" -eq 3 ]
 }

--- a/pkg/opts/opts.go
+++ b/pkg/opts/opts.go
@@ -149,7 +149,7 @@ func (s *StringListFlag) Set(v string) error {
 func (s *StringListFlag) String() string {
 	q := make([]string, len(s.args))
 	for i, a := range s.args {
-		q[i] = fmt.Sprintf("%q", a)
+		q[i] = shellQuote(a)
 	}
 	return fmt.Sprintf("(%v)", strings.Join(q, " "))
 }
@@ -197,6 +197,11 @@ func flagSet(c Config) (*flag.FlagSet, error) {
 	return fs, nil
 }
 
+// shellQuote wraps a string in single quotes and safely escapes existing single quotes.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}
+
 func declLine(name, value, falseVal, prefix, decl string, toUpper, quote bool) string {
 	r := strings.NewReplacer("-", "_")
 	name = r.Replace(name)
@@ -204,7 +209,7 @@ func declLine(name, value, falseVal, prefix, decl string, toUpper, quote bool) s
 	if toUpper {
 		fullVarName = strings.ToUpper(fullVarName)
 	}
-	assignment := fmt.Sprintf("%v=%q", fullVarName, value)
+	assignment := fmt.Sprintf("%v=%s", fullVarName, shellQuote(value))
 	if !quote {
 		assignment = fmt.Sprintf("%v=%v", fullVarName, value)
 	}
@@ -252,7 +257,7 @@ func wrArgs(args []string, fs *flag.FlagSet, prefix, decl string, toUpper bool, 
 	}
 	var a []string
 	for _, arg := range fs.Args() {
-		a = append(a, fmt.Sprintf("%q", arg))
+		a = append(a, shellQuote(arg))
 	}
 	allArgs := strings.Join(a, " ")
 	dl := declLine("args__", fmt.Sprintf("(%s)", allArgs), "()", prefix, decl, toUpper, false)

--- a/pkg/opts/opts_test.go
+++ b/pkg/opts/opts_test.go
@@ -31,9 +31,9 @@ flags:
   default: "value"
 `,
 			expected: `# gotopt2:generated:begin
-gotopt2_baz="value"
-gotopt2_foo="bar"
-gotopt2_args__=("arg")
+gotopt2_baz='value'
+gotopt2_foo='bar'
+gotopt2_args__=('arg')
 # gotopt2:generated:end
 `,
 		},
@@ -57,8 +57,8 @@ flags:
   type: stringlist
 `,
 			expected: `# gotopt2:generated:begin
-gotopt2_foo__list=("bar" "baz" "bat")
-gotopt2_args__=("arg")
+gotopt2_foo__list=('bar' 'baz' 'bat')
+gotopt2_args__=('arg')
 # gotopt2:generated:end
 `,
 		},
@@ -88,8 +88,8 @@ flags:
   type: string
 `,
 			expected: `# gotopt2:generated:begin
-some_declaration gotopt2_foo="bar"
-some_declaration gotopt2_args__=("arg")
+some_declaration gotopt2_foo='bar'
+some_declaration gotopt2_args__=('arg')
 # gotopt2:generated:end
 `,
 		},
@@ -104,8 +104,8 @@ flags:
   type: string
 `,
 			expected: `# gotopt2:generated:begin
-some_prefix_gotopt2_foo="bar"
-some_prefix_gotopt2_args__=("arg")
+some_prefix_gotopt2_foo='bar'
+some_prefix_gotopt2_args__=('arg')
 # gotopt2:generated:end
 `,
 		},
@@ -124,9 +124,9 @@ flags:
   default: "value"
 `,
 			expected: `# gotopt2:generated:begin
-GOTOPT2_BAZ="value"
-GOTOPT2_FOO="bar"
-GOTOPT2_ARGS__=("arg")
+GOTOPT2_BAZ='value'
+GOTOPT2_FOO='bar'
+GOTOPT2_ARGS__=('arg')
 # gotopt2:generated:end
 `,
 		},
@@ -152,7 +152,7 @@ flags:
   type: bool
 `,
 			expected: `# gotopt2:generated:begin
-gotopt2_foo="true"
+gotopt2_foo='true'
 # gotopt2:generated:end
 `,
 		},
@@ -166,7 +166,7 @@ flags:
   type: bool
 `,
 			expected: `# gotopt2:generated:begin
-gotopt2_foo_bar="true"
+gotopt2_foo_bar='true'
 # gotopt2:generated:end
 `,
 		},
@@ -180,8 +180,8 @@ flags:
   type: bool
 `,
 			expected: `# gotopt2:generated:begin
-gotopt2_foo=""
-gotopt2_args__=("--foo")
+gotopt2_foo=''
+gotopt2_args__=('--foo')
 # gotopt2:generated:end
 `,
 		},
@@ -195,7 +195,7 @@ flags:
   type: bool
 `,
 			expected: `# gotopt2:generated:begin
-gotopt2_foo=""
+gotopt2_foo=''
 # gotopt2:generated:end
 `,
 		},
@@ -210,7 +210,7 @@ flags:
   type: bool
 `,
 			expected: `# gotopt2:generated:begin
-gotopt2_foo="false"
+gotopt2_foo='false'
 # gotopt2:generated:end
 `,
 		},
@@ -224,8 +224,8 @@ flags:
   type: bool
 `,
 			expected: `# gotopt2:generated:begin
-gotopt2_foo="true"
-gotopt2_args__=("file1" "file2")
+gotopt2_foo='true'
+gotopt2_args__=('file1' 'file2')
 # gotopt2:generated:end
 `,
 		},
@@ -251,11 +251,25 @@ flags:
   type: bool
 `,
 			expected: `# gotopt2:generated:begin
-gotopt2_boolarg="true"
-gotopt2_intarg="10"
-gotopt2_strarg2="bar"
-gotopt2_strarg="foo"
-gotopt2_args__=("param1" "param2")
+gotopt2_boolarg='true'
+gotopt2_intarg='10'
+gotopt2_strarg2='bar'
+gotopt2_strarg='foo'
+gotopt2_args__=('param1' 'param2')
+# gotopt2:generated:end
+`,
+		},
+		{
+			name: "Command Injection",
+			args: []string{"--strarg", "$(echo hacked)", "`rm -rf /`", "a'b"},
+			input: `
+flags:
+- name: "strarg"
+  type: string
+`,
+			expected: `# gotopt2:generated:begin
+gotopt2_strarg='$(echo hacked)'
+gotopt2_args__=('` + "`" + `rm -rf /` + "`" + `' 'a'"'"'b')
 # gotopt2:generated:end
 `,
 		},


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Command Injection. The tool `gotopt2` generated bash output that wrapped user inputs in double quotes. When host shell scripts evaluated this output using `eval`, any user inputs containing command substitution syntax (e.g. `$(hacked)` or `` `hacked` ``) were executed by bash.
🎯 **Impact:** Remote Code Execution (RCE) / Arbitrary command execution on any system running a shell script that uses `gotopt2` and `eval`s its output.
🔧 **Fix:** Changed the formatting of string outputs to wrap them securely in single quotes instead of double quotes. Internal single quotes are properly escaped (`'"'"'`), making it impossible to perform command substitutions.
✅ **Verification:** Verified by running `go test ./...` and `bazel test //...` which pass, including an added explicit command injection unit test. Also validated via a local bash testing script.

---
*PR created automatically by Jules for task [16024978124642898399](https://jules.google.com/task/16024978124642898399) started by @filmil*