### PR TITLE
🧹 remove unused parameter in declLine function

### DIFF
--- a/pkg/opts/opts.go
+++ b/pkg/opts/opts.go
@@ -202,7 +202,7 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
-func declLine(name, value, falseVal, prefix, decl string, toUpper, quote bool) string {
+func declLine(name, value, prefix, decl string, toUpper, quote bool) string {
 	r := strings.NewReplacer("-", "_")
 	name = r.Replace(name)
 	fullVarName := fmt.Sprintf("%vgotopt2_%v", prefix, name)
@@ -240,7 +240,7 @@ func wrFlags(fs *flag.FlagSet, falseVal string, toUpper bool,
 			name = fmt.Sprintf("%v__list", name)
 			quote = false
 		}
-		dl := declLine(name, v, falseVal, prefix, decl, toUpper, quote)
+		dl := declLine(name, v, prefix, decl, toUpper, quote)
 		out = append(out, fmt.Sprintf("%s\n", dl))
 	})
 	// Ensure that the output is stable.
@@ -260,6 +260,6 @@ func wrArgs(args []string, fs *flag.FlagSet, prefix, decl string, toUpper bool, 
 		a = append(a, shellQuote(arg))
 	}
 	allArgs := strings.Join(a, " ")
-	dl := declLine("args__", fmt.Sprintf("(%s)", allArgs), "()", prefix, decl, toUpper, false)
+	dl := declLine("args__", fmt.Sprintf("(%s)", allArgs), prefix, decl, toUpper, false)
 	fmt.Fprintf(w, "%s\n", dl)
 }


### PR DESCRIPTION
### 🎯 What
The `falseVal` parameter in the `declLine` function signature in `pkg/opts/opts.go` was not used within the function body.

### 💡 Why
Removing unused parameters reduces complexity, improves code readability, and makes the function signature more concise.

### ✅ Verification
I verified that the parameter was indeed unused in the function body. I updated all call sites in `wrFlags` and `wrArgs` to match the new signature. I also confirmed that the code structure remains correct.

### ✨ Result
A cleaner and more maintainable `declLine` function signature.

---
*PR created automatically by Jules for task [2020543362692374151](https://jules.google.com/task/2020543362692374151) started by @filmil*