### PR TITLE
test: add a test confirming that gotopt2 exits with 11 when --help is supplied

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,5 +12,5 @@ buildifier(
 alias(
     name = "bin",
     actual = "@multitool//tools/gotopt2",
-    visibility = [ "//visibility:public" ],
+    visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -316,7 +316,7 @@
   "moduleExtensions": {
     "@@bazel_bats+//:extensions.bzl%bazel_bats_deps": {
       "general": {
-        "bzlTransitiveDigest": "T2P3qHOgZ09qyacxD/Xs0r2MTrGsJjQ0AzSh2J/WlXw=",
+        "bzlTransitiveDigest": "JKBE/jUTRiWkediih9MYEUJaC8cmHo1xY4+8OzQf2W4=",
         "usagesDigest": "t+ex/oJhALiD6nk6VMpJT83/RVXO6TaIVwWMSo4V6sA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -8,7 +8,7 @@ sh_binary(
         "example.sh",
     ],
     data = [
-        "@multitool//tools/gotopt2:cwd",
         "@bazel_tools//tools/bash/runfiles",
-    ]
+        "@multitool//tools/gotopt2:cwd",
+    ],
 )

--- a/cmd/gotopt2/BUILD.bazel
+++ b/cmd/gotopt2/BUILD.bazel
@@ -1,7 +1,7 @@
-load("//build:my_package_name.bzl", "name_part_from_command_line")
 load("@bazel_bats//:rules.bzl", "bats_test")
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
+load("//build:my_package_name.bzl", "name_part_from_command_line")
 
 go_library(
     name = "gotopt2_lib",
@@ -9,6 +9,12 @@ go_library(
     importpath = "github.com/filmil/gotopt2/cmd/gotopt2",
     visibility = ["//visibility:private"],
     deps = ["//pkg/opts"],
+)
+
+go_test(
+    name = "gotopt2_lib_test",
+    srcs = ["main_test.go"],
+    embed = [":gotopt2_lib"],
 )
 
 go_binary(

--- a/cmd/gotopt2/main.go
+++ b/cmd/gotopt2/main.go
@@ -22,7 +22,7 @@ func main() {
 	if err := opts.Run(os.Stdin, os.Args[1:], os.Stdout); err != nil {
 		if err == flag.ErrHelp {
 			// flag.ErrHelp means that the flag parser has written out the
-			// usage.
+			// usage. We exit with code 11 to signal help (fixes issue #11).
 			os.Exit(11)
 		}
 		os.Exit(142)

--- a/cmd/gotopt2/main_test.go
+++ b/cmd/gotopt2/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestHelpExitCode(t *testing.T) {
+	if os.Getenv("BE_CRASHER") == "1" {
+		// Mock the stdin so it reads a config
+		r, w, _ := os.Pipe()
+		w.WriteString("flags:\n- name: foo\n  type: string\n")
+		w.Close()
+		os.Stdin = r
+
+		os.Args = []string{"gotopt2", "--help"}
+		main()
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestHelpExitCode")
+	cmd.Env = append(os.Environ(), "BE_CRASHER=1")
+	err := cmd.Run()
+	if e, ok := err.(*exec.ExitError); ok && !e.Success() {
+		if e.ExitCode() != 11 {
+			t.Fatalf("expected exit code 11, got %d", e.ExitCode())
+		}
+		return
+	}
+	t.Fatalf("process ran with err %v, want exit status 11", err)
+}

--- a/pkg/opts/BUILD.bazel
+++ b/pkg/opts/BUILD.bazel
@@ -5,7 +5,7 @@ go_library(
     srcs = ["opts.go"],
     importpath = "github.com/filmil/gotopt2/pkg/opts",
     visibility = ["//visibility:public"],
-    deps = ["@in_gopkg_yaml_v3//:go_default_library"],
+    deps = ["@in_gopkg_yaml_v3//:yaml_v3"],
 )
 
 go_test(


### PR DESCRIPTION
Adds a Go test to verify that `gotopt2` exits with code `11` when `--help` is supplied, as requested in issue #11. The test executes the program internally using `os/exec` to cleanly assert the exit code without relying on an external shell. It has been integrated into Bazel via `go_test` in `cmd/gotopt2/BUILD.bazel`.

---
*PR created automatically by Jules for task [16396652450816860908](https://jules.google.com/task/16396652450816860908) started by @filmil*