### PR TITLE
🧪 test: Add missing error test for FType UnmarshalYAML

### DIFF
--- a/pkg/opts/opts_test.go
+++ b/pkg/opts/opts_test.go
@@ -273,6 +273,16 @@ gotopt2_args__=('` + "`" + `rm -rf /` + "`" + `' 'a'"'"'b')
 # gotopt2:generated:end
 `,
 		},
+		{
+			name: "Invalid FType Unmarshal",
+			args: []string{},
+			input: `
+flags:
+- name: "foo"
+  type: ["invalid_array"]
+`,
+			wantError: fmt.Errorf("not a string:"),
+		},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
🎯 **What:** Added a missing error test for FType UnmarshalYAML to ensure it handles invalid YAML correctly.
📊 **Coverage:** The scenario where a non-string YAML value (an array) is passed as the flag's `type` field is now covered by expecting a `fmt.Errorf("not a string:")`.
✨ **Result:** Test coverage for `FType.UnmarshalYAML`'s error condition is improved.

---
*PR created automatically by Jules for task [6124925059791579576](https://jules.google.com/task/6124925059791579576) started by @filmil*