### PR TITLE
🔒 Fix bash variable name and declaration injection (v2)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Command injection was possible because `gotopt2` output strings wrapped in double quotes (e.g., `gotopt2_var="$(echo hacked)"`), which caused the host bash script using `eval` to evaluate the inner command substitution.
 **Learning:** When generating shell code intended for `eval`, double quotes are unsafe if the content includes user input, because they allow parameter expansion and command substitution.
 **Prevention:** Always wrap generated string values in single quotes, and escape internal single quotes as `'"'"'` (or similar), to ensure the string is treated purely as a literal value by the shell parser.
+
+## 2025-04-14 - [Command Injection via Unsanitized Variable Names in eval Payload]
+**Vulnerability:** Malicious input in configuration fields like `name`, `prefix`, and `declaration` could inject arbitrary shell commands (e.g., `prefix: "p; echo HACKED; "`) because these fields were used unsanitized in the generated bash script that is typically executed via `eval`.
+**Learning:** When generating bash code from user-provided input, not only the values but also the variable names and command prefixes must be sanitized to prevent command injection.
+**Prevention:** Sanitize all components used in generating shell scripts (variable names, prefixes, declaration keywords) to only include safe characters like alphanumeric and underscores ([a-zA-Z0-9_]).

--- a/pkg/opts/opts.go
+++ b/pkg/opts/opts.go
@@ -202,9 +202,20 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
+// sanitize replaces any character that is not alphanumeric or underscore with an underscore.
+func sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			return r
+		}
+		return '_'
+	}, s)
+}
+
 func declLine(name, value, falseVal, prefix, decl string, toUpper, quote bool) string {
-	r := strings.NewReplacer("-", "_")
-	name = r.Replace(name)
+	name = sanitize(name)
+	prefix = sanitize(prefix)
+	decl = sanitize(decl)
 	fullVarName := fmt.Sprintf("%vgotopt2_%v", prefix, name)
 	if toUpper {
 		fullVarName = strings.ToUpper(fullVarName)

--- a/pkg/opts/opts_test.go
+++ b/pkg/opts/opts_test.go
@@ -273,6 +273,21 @@ gotopt2_args__=('` + "`" + `rm -rf /` + "`" + `' 'a'"'"'b')
 # gotopt2:generated:end
 `,
 		},
+		{
+			name: "Malicious flag name, prefix, and declaration",
+			args: []string{"-a=1"},
+			input: `
+prefix: "p;echo HACKED_PREFIX;"
+declaration: "d;echo HACKED_DECL;"
+flags:
+- name: "a"
+  type: string
+`,
+			expected: `# gotopt2:generated:begin
+d_echo_HACKED_DECL_ p_echo_HACKED_PREFIX_gotopt2_a='1'
+# gotopt2:generated:end
+`,
+		},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
The `gotopt2` program generates bash variable assignments from a YAML configuration provided via stdin. Previously, certain configuration fields (like `name`, `prefix`, and `declaration`) were not properly sanitized, allowing for potential shell command injection if the output was executed with `eval`. 

This PR addresses the vulnerability by:
1. Implementing a `sanitize` function that whitelists only alphanumeric characters and underscores.
2. Applying this sanitization to all parts of the generated assignment line that are derived from configuration fields.
3. Adding a new regression test to ensure that malicious inputs (e.g., `;echo HACKED;`) are transformed into safe identifiers.

This version is rebased on top of the latest main branch.


---
*PR created automatically by Jules for task [17552785367977661005](https://jules.google.com/task/17552785367977661005) started by @filmil*