### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection via configuration parameters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Command injection was possible because `gotopt2` output strings wrapped in double quotes (e.g., `gotopt2_var="$(echo hacked)"`), which caused the host bash script using `eval` to evaluate the inner command substitution.
 **Learning:** When generating shell code intended for `eval`, double quotes are unsafe if the content includes user input, because they allow parameter expansion and command substitution.
 **Prevention:** Always wrap generated string values in single quotes, and escape internal single quotes as `'"'"'` (or similar), to ensure the string is treated purely as a literal value by the shell parser.
+## 2025-02-05 - [Command Injection via Configuration Parameters in eval Payload]
+**Vulnerability:** Command injection was possible because `gotopt2` output bash variables without sanitizing the `name`, `prefix`, and `declaration` configuration inputs. An attacker could inject arbitrary commands by providing values like `foo;echo INJECTED`.
+**Learning:** Even configurable prefixes and variable names can be vectors for command injection if the output is evaluated (`eval`). Unsanitized configuration strings can break out of variable assignment contexts.
+**Prevention:** Strictly sanitize all variables, prefixes, and declarations using an allowlist approach to ensure only valid Bash identifier characters (`[a-zA-Z0-9_]`) or specific declaration characters (`[a-zA-Z0-9_ \-]`) are emitted into shell scripts.

--- a/pkg/opts/opts.go
+++ b/pkg/opts/opts.go
@@ -202,9 +202,32 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
+func sanitizeBashIdentifier(s string) string {
+	var sb strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
+func sanitizeBashDecl(s string) string {
+	var sb strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == ' ' {
+			sb.WriteRune(r)
+		}
+	}
+	return sb.String()
+}
+
 func declLine(name, value, prefix, decl string, toUpper, quote bool) string {
 	r := strings.NewReplacer("-", "_")
 	name = r.Replace(name)
+	name = sanitizeBashIdentifier(name)
+	prefix = sanitizeBashIdentifier(prefix)
+	decl = sanitizeBashDecl(decl)
 	fullVarName := fmt.Sprintf("%vgotopt2_%v", prefix, name)
 	if toUpper {
 		fullVarName = strings.ToUpper(fullVarName)

--- a/pkg/opts/opts_test.go
+++ b/pkg/opts/opts_test.go
@@ -274,6 +274,22 @@ gotopt2_args__=('` + "`" + `rm -rf /` + "`" + `' 'a'"'"'b')
 `,
 		},
 		{
+			name: "Command Injection via configuration",
+			args: []string{"-foo;echo INJECTED=bar", "arg"},
+			input: `
+prefix: "x;echo INJECTED;"
+declaration: "declare;echo INJECTED"
+flags:
+- name: "foo;echo INJECTED"
+  type: string
+`,
+			expected: `# gotopt2:generated:begin
+declareecho INJECTED xechoINJECTEDgotopt2_fooechoINJECTED='bar'
+declareecho INJECTED xechoINJECTEDgotopt2_args__=('arg')
+# gotopt2:generated:end
+`,
+		},
+		{
 			name: "Invalid FType Unmarshal",
 			args: []string{},
 			input: `


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command injection was possible because `gotopt2` output bash variables without sanitizing the `name`, `prefix`, and `declaration` configuration inputs. An attacker could inject arbitrary commands by providing values like `foo;echo INJECTED`.
🎯 Impact: This allows arbitrary code execution during the `eval` of the generated bash code.
🔧 Fix: Add strict sanitization for all variables, prefixes, and declarations using an allowlist approach to ensure only valid Bash identifier characters (`[a-zA-Z0-9_]`) or specific declaration characters (`[a-zA-Z0-9_ \-]`) are emitted into shell scripts.
✅ Verification: Ran unit tests and added a specific `Command Injection via configuration` test.

---
*PR created automatically by Jules for task [15029943181885151781](https://jules.google.com/task/15029943181885151781) started by @filmil*