### PR TITLE
ci: include gotopt2-generator in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,14 @@ jobs:
       - name: "Test"
         run: "bazel test --test_output=errors //..."
       - name: "Build binaries for ${{ matrix.os }}_${{ matrix.arch }}"
-        run: "bazel build --platforms=@io_bazel_rules_go//go/toolchain:${{ matrix.os }}_${{ matrix.arch}} --//cmd/gotopt2:name_part_from_command_line=${{ matrix.os }}-${{ matrix.arch }} //cmd/gotopt2:zip"
+        run: "bazel build --platforms=@io_bazel_rules_go//go/toolchain:${{ matrix.os }}_${{ matrix.arch}} --//cmd/gotopt2:name_part_from_command_line=${{ matrix.os }}-${{ matrix.arch }} //cmd/gotopt2:zip //cmd/gotopt2-generator:zip"
       - name: "Publish ${{ matrix.os }}_${{ matrix.arch }}"
         uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           allowUpdates: true
-          artifacts: "bazel-bin/cmd/gotopt2/gotopt2-${{ matrix.os }}-${{ matrix.arch }}.zip"
+          artifacts: "bazel-bin/cmd/gotopt2/gotopt2-${{ matrix.os }}-${{ matrix.arch }}.zip,bazel-bin/cmd/gotopt2-generator/gotopt2-generator-${{ matrix.os }}-${{ matrix.arch }}.zip"
   source-archive:
     runs-on: ubuntu-latest
     steps:

--- a/cmd/gotopt2-generator/BUILD.bazel
+++ b/cmd/gotopt2-generator/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_pkg//pkg:zip.bzl", "pkg_zip")
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 go_library(
@@ -17,6 +18,16 @@ go_binary(
     name = "gotopt2-generator",
     embed = [":gotopt2-generator_lib"],
     visibility = ["//visibility:public"],
+)
+
+pkg_zip(
+    name = "zip",
+    srcs = [
+        ":gotopt2-generator",
+    ],
+    package_dir = "gotopt2-generator",
+    package_file_name = "gotopt2-generator-{name_part}.zip",
+    package_variables = "//cmd/gotopt2:name_part_from_command_line",
 )
 
 sh_test(

--- a/cmd/gotopt2/BUILD.bazel
+++ b/cmd/gotopt2/BUILD.bazel
@@ -58,6 +58,7 @@ sh_test(
 name_part_from_command_line(
     name = "name_part_from_command_line",
     build_setting_default = "@set_me@",
+    visibility = ["//visibility:public"],
 )
 
 pkg_zip(


### PR DESCRIPTION
This PR updates the release workflow to include the newly implemented gotopt2-generator binary alongside the main gotopt2 binary.

- Added a pkg_zip target in cmd/gotopt2-generator/BUILD.bazel to bundle the generator.
- Updated cmd/gotopt2/BUILD.bazel to make the name_part_from_command_line build setting public, allowing it to be used for the generator's zip filename.
- Modified .github/workflows/release.yml to build and publish the gotopt2-generator zip files during the release process.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt:
new feature, new pr: rebase from main, then modify github workflows to release the new binary alongside gotopt2
