### PR TITLE
build: update gotopt2 binary to v2.4.1 in multitool.lock.json

### DIFF
--- a/multitool.lock.json
+++ b/multitool.lock.json
@@ -1,15 +1,15 @@
 {
-    "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
-    "gotopt2": {
-        "binaries": [
-            {
-                "kind": "archive",
-                "url": "https://github.com/filmil/gotopt2/releases/download/v2.1.4/gotopt2-linux-amd64.zip",
-                "sha256": "a8542382a8787e71deb75524577f1b13177ae18939f36881522f4eac2949189a",
-                "os": "linux",
-                "file": "gotopt2/gotopt2",
-                "cpu": "x86_64"
-            }
-        ]
-    }
+  "$schema": "https://raw.githubusercontent.com/theoremlp/rules_multitool/main/lockfile.schema.json",
+  "gotopt2": {
+    "binaries": [
+      {
+        "kind": "archive",
+        "url": "https://github.com/filmil/gotopt2/releases/download/v2.4.1/gotopt2-linux-amd64.zip",
+        "sha256": "4be1ababcda1ce4df728f6d7ca65fdf0fce0cecfc7e0a28a24d06ad820270568",
+        "os": "linux",
+        "file": "gotopt2/gotopt2",
+        "cpu": "x86_64"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
This PR updates the multitool.lock.json to point the gotopt2 binary dependency to the latest released version v2.4.1.

Per user request, the gotopt2-generator binary has been omitted from this lockfile update as it has not yet completed a full release cycle.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt:
rebase on main, then new feature: update @multitool.lock.json to include the new binary. Also use the latest built version of all binaries, send pr

User steering update:
don't add new binary to multitool lockfile, it has not been released yet. just send pr without it
