### PR TITLE
ci: include gotopt2-generator in tag-and-release workflow

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -90,8 +90,8 @@ jobs:
         run: |
           bazel build \
             --platforms=@rules_go//go/toolchain:${{ matrix.os }}_${{ matrix.arch}} \
-            --${ZIP_PACKAGE}:name_part_from_command_line=${{ matrix.os }}-${{ matrix.arch }} \
-            ${ZIP_PACKAGE}:zip
+            --//cmd/gotopt2:name_part_from_command_line=${{ matrix.os }}-${{ matrix.arch }} \
+            //cmd/gotopt2:zip //cmd/gotopt2-generator:zip
       - name: Find version tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
@@ -105,6 +105,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           allowUpdates: true
-          artifacts: "${{ env.BINARY_NAME }}-${{ matrix.os }}-${{ matrix.arch }}.zip"
+          artifacts: "bazel-bin/cmd/gotopt2/gotopt2-${{ matrix.os }}-${{ matrix.arch }}.zip,bazel-bin/cmd/gotopt2-generator/gotopt2-generator-${{ matrix.os }}-${{ matrix.arch }}.zip"
           tag: ${{ steps.tag_version.outputs.previous_tag }}
 


### PR DESCRIPTION
This PR updates the tag-and-release.yml workflow to ensure that the newly added gotopt2-generator binary is compiled and published alongside the main gotopt2 binary during release generation.

Both binaries are now built with the correct platform architectures and uploaded as separate .zip archives to the release tag, mirroring the recent change to release.yml.

This pull request has been created by an automated coding assistant, with human supervision.

Prompt:
rebase from main, then new feature: modify the workflows to release both the gotopt2 and gotopt2-generator binaries, as separate archives
