### PR TITLE
docs(integration): add example of using generated bash script in sh_library

### DIFF
--- a/integration/BUILD.bazel
+++ b/integration/BUILD.bazel
@@ -37,3 +37,25 @@ sh_test(
         ":example_parser",
     ],
 )
+
+
+load("@rules_shell//shell:sh_library.bzl", "sh_library")
+
+sh_library(
+    name = "example_parser_lib",
+    srcs = ["example_parser.sh"],
+)
+
+sh_test(
+    name = "my_script_test",
+    srcs = ["my_script_test.sh"],
+    args = [
+        "$(location my_script.sh)",
+        "$(location :example_parser)",
+    ],
+    data = [
+        "my_script.sh",
+        ":example_parser_lib",
+        ":example_parser",
+    ],
+)

--- a/integration/my_script.sh
+++ b/integration/my_script.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# A script that uses the generated parser
+
+# Source the generated parser
+source "${1}"
+shift
+
+# Call the generated parse_args function
+parse_args "$@"
+
+# Check if the parsing succeeded and do something with the output
+if [ -n "${gotopt2_my_flag:-}" ]; then
+  echo "Success: ${gotopt2_my_flag}"
+else
+  echo "Failure: my_flag was not set"
+  exit 1
+fi

--- a/integration/my_script_test.sh
+++ b/integration/my_script_test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# A test script to verify my_script.sh
+
+SCRIPT_PATH="${1}"
+PARSER_PATH="${2}"
+
+# Run the script with the parser path and a test flag
+OUTPUT=$("${SCRIPT_PATH}" "${PARSER_PATH}" --my-flag=test_value)
+
+if [[ "${OUTPUT}" == *"Success: test_value"* ]]; then
+  exit 0
+else
+  echo "Expected to contain 'Success: test_value', got '${OUTPUT}'"
+  exit 1
+fi


### PR DESCRIPTION
This commit introduces a practical example within the integration workspace demonstrating how to consume the generated parser shell script using an sh_library rule and validating it via an sh_test.