### PR TITLE
feat: add trueValue configuration for boolean flags

### DIFF
--- a/cmd/gotopt2-generator/compare_test.sh
+++ b/cmd/gotopt2-generator/compare_test.sh
@@ -89,4 +89,12 @@ flags:
 '
 run_test "Help" "$CONFIG_3" "--help"
 
+CONFIG_4='
+trueValue: "on"
+flags:
+- name: "mybool"
+  type: bool
+'
+run_test "TrueValue" "$CONFIG_4" "--mybool"
+
 echo "All tests passed."

--- a/cmd/gotopt2-generator/main.go
+++ b/cmd/gotopt2-generator/main.go
@@ -39,6 +39,7 @@ type TemplateFlag struct {
 	Type          opts.FType
 	ActualVarName string
 	DefaultValue  string
+	TrueValue     string
 	Help          string
 }
 
@@ -64,11 +65,20 @@ func generateBash(c opts.Config, w io.Writer) error {
 
 	var outputs []string
 
+	trueVal := c.TrueValue
+	if trueVal == "" {
+		trueVal = "true"
+	}
+
 	for _, f := range c.Flags {
 		actualVarName := varName(f.Name, c.Prefix, c.AllCaps)
 		def := f.RawDefault
-		if f.Type == opts.FTBool && def == "" {
-			def = c.FalseValue
+		if f.Type == opts.FTBool {
+			if def == "" || def == "false" {
+				def = c.FalseValue
+			} else if def == "true" {
+				def = trueVal
+			}
 		}
 
 		data.Flags = append(data.Flags, TemplateFlag{
@@ -76,6 +86,7 @@ func generateBash(c opts.Config, w io.Writer) error {
 			Type:          f.Type,
 			ActualVarName: actualVarName,
 			DefaultValue:  def,
+			TrueValue:     trueVal,
 			Help:          f.Help,
 		})
 		varNameStr := f.Name

--- a/cmd/gotopt2-generator/parser.sh.tmpl
+++ b/cmd/gotopt2-generator/parser.sh.tmpl
@@ -24,7 +24,7 @@ parse_args() {
 {{- range .Flags }}
   {{- if eq .Type 3 }}
       --{{ .Name }})
-        {{ .ActualVarName }}="true"
+        {{ .ActualVarName }}="{{ .TrueValue }}"
         shift
         ;;
   {{- else if eq .Type 4 }}

--- a/cmd/gotopt2/gotopt2_test.bats
+++ b/cmd/gotopt2/gotopt2_test.bats
@@ -79,3 +79,21 @@ EOF
   [ "${lines[1]}" == "  -list value" ]
 }
 
+@test "TrueValue config" {
+  run "${GOTOPT2}" --mybool <<EOF
+trueValue: "on"
+flags:
+- name: "mybool"
+  type: bool
+  help: ""
+EOF
+  echo "${status}"
+  echo "${lines[0]}"
+  echo "${lines[1]}"
+  echo "${lines[2]}"
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" == "# gotopt2:generated:begin" ]
+  [ "${lines[1]}" == "gotopt2_mybool='on'" ]
+  [ "${lines[2]}" == "# gotopt2:generated:end" ]
+  [ "${#lines[@]}" -eq 3 ]
+}

--- a/pkg/opts/opts.go
+++ b/pkg/opts/opts.go
@@ -22,6 +22,9 @@ type Config struct {
 	// that text to be "false", or "off" or some such.  Note that this does not
 	// affect the way the user can specify the flag.
 	FalseValue string `yaml:"falseValue"`
+	// TrueValue is the value to generate for a true-valued Boolean variable.
+	// It is "true" by default.
+	TrueValue string `yaml:"trueValue"`
 	// AllCaps causes the variable name to be rendered in ALL_CAPS.
 	AllCaps bool `yaml:"ALL_CAPS"`
 	// Prefix is prepended to the full variable name.
@@ -91,7 +94,7 @@ func Run(r io.Reader, args []string, w io.Writer) error {
 	}
 
 	fmt.Fprintf(w, "# gotopt2:generated:begin\n")
-	wrFlags(fs, c.FalseValue, c.AllCaps, c.Prefix, c.Declaration, w)
+	wrFlags(fs, c.FalseValue, c.TrueValue, c.AllCaps, c.Prefix, c.Declaration, w)
 	wrArgs(args, fs, c.Prefix, c.Declaration, c.AllCaps, w)
 	fmt.Fprintf(w, "# gotopt2:generated:end\n")
 	return nil
@@ -162,6 +165,7 @@ func config(r io.Reader) (Config, error) {
 		c   Config
 		err error
 	)
+	c.TrueValue = "true"
 	if err = d.Decode(&c); err != nil {
 		return c, fmt.Errorf("while decoding configuration: %v", err)
 	}
@@ -242,7 +246,7 @@ func declLine(name, value, prefix, decl string, toUpper, quote bool) string {
 	return strings.Join([]string{decl, assignment}, " ")
 }
 
-func wrFlags(fs *flag.FlagSet, falseVal string, toUpper bool,
+func wrFlags(fs *flag.FlagSet, falseVal string, trueVal string, toUpper bool,
 	prefix string, decl string, w io.Writer) {
 	// Produce the output
 	var out []string
@@ -251,11 +255,14 @@ func wrFlags(fs *flag.FlagSet, falseVal string, toUpper bool,
 		type isbooler interface {
 			IsBoolFlag() bool
 		}
-		if _, ok := f.Value.(isbooler); !ok || f.Value.String() != "false" {
+		if _, ok := f.Value.(isbooler); ok {
+			if f.Value.String() == "true" {
+				v = trueVal
+			} else {
+				v = falseVal
+			}
+		} else {
 			v = f.Value.String()
-		}
-		if v == "" {
-			v = falseVal
 		}
 		name := f.Name
 		quote := true

--- a/pkg/opts/opts_test.go
+++ b/pkg/opts/opts_test.go
@@ -215,6 +215,51 @@ gotopt2_foo='false'
 `,
 		},
 		{
+			name: "Bool True with custom value for true",
+			args: []string{"--foo"},
+			input: `
+trueValue: "on"
+flags:
+- name: "foo"
+  help: "This is foo"
+  type: bool
+`,
+			expected: `# gotopt2:generated:begin
+gotopt2_foo='on'
+# gotopt2:generated:end
+`,
+		},
+		{
+			name: "Bool True explicit with custom value for true",
+			args: []string{"--foo=true"},
+			input: `
+trueValue: "on"
+flags:
+- name: "foo"
+  help: "This is foo"
+  type: bool
+`,
+			expected: `# gotopt2:generated:begin
+gotopt2_foo='on'
+# gotopt2:generated:end
+`,
+		},
+		{
+			name: "Bool False with custom value for true (should output empty by default without falseValue)",
+			args: []string{},
+			input: `
+trueValue: "on"
+flags:
+- name: "foo"
+  help: "This is foo"
+  type: bool
+`,
+			expected: `# gotopt2:generated:begin
+gotopt2_foo=''
+# gotopt2:generated:end
+`,
+		},
+		{
 			name: "Bool with arg",
 			args: []string{"--foo", "file1", "file2"},
 			input: `


### PR DESCRIPTION
Fixes #10 by adding `trueValue` to the `gotopt2` and `gotopt2-generator` configurations, allowing users to customize the string output when a boolean flag is present, similar to the existing `falseValue` option.

- Added `TrueValue` to `opts.Config` with a default of `"true"`.
- Updated `pkg/opts/opts.go` generation logic to properly use `trueVal` and `falseVal` specifically for `isbooler` interfaces.
- Updated `cmd/gotopt2-generator/main.go` and `parser.sh.tmpl` to use the `TrueValue` setting when writing out assignments for boolean flags.
- Added tests to cover custom `trueValue` scenarios.

---
*PR created automatically by Jules for task [5471658573704069724](https://jules.google.com/task/5471658573704069724) started by @filmil*