### PR TITLE
ci: trigger publish to bazel registry on release

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -25,6 +25,8 @@ on:
 jobs:
   tag:
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.tag_version.outputs.new_tag }}
     steps:
       - name: Setup bazel
         uses: bazel-contrib/setup-bazel@0.19.0
@@ -108,3 +110,10 @@ jobs:
           artifacts: "bazel-bin/cmd/gotopt2/gotopt2-${{ matrix.os }}-${{ matrix.arch }}.zip,bazel-bin/cmd/gotopt2-generator/gotopt2-generator-${{ matrix.os }}-${{ matrix.arch }}.zip"
           tag: ${{ steps.tag_version.outputs.previous_tag }}
 
+  publish:
+    needs: [tag, release]
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag_name: ${{ needs.tag.outputs.tag_name }}
+    secrets:
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
This PR updates the GitHub workflow "tag and release" (`.github/workflows/tag-and-release.yml`) to also invoke the "Publish to my Bazel registry" workflow (`.github/workflows/publish.yml`) after the test and release steps are successfully completed.

It does this by outputting `tag_name` from the `tag` step and adding a new `publish` job that uses `publish.yml` with the correct `secrets.BCR_PUBLISH_TOKEN` to ensure the registry gets published to automatically along with the tags and releases.

Closes #79

---
*PR created automatically by Jules for task [3959145906227929711](https://jules.google.com/task/3959145906227929711) started by @filmil*