### PR TITLE
🧹 chore: Remove commented-out dead code from config parser

### DIFF
--- a/pkg/opts/opts.go
+++ b/pkg/opts/opts.go
@@ -159,8 +159,6 @@ func (s *StringListFlag) String() string {
 
 func config(r io.Reader) (Config, error) {
 	d := yaml.NewDecoder(r)
-	// SetStrict is not supported in v3.
-	//d.SetStrict(true)
 	var (
 		c   Config
 		err error


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code from `pkg/opts/opts.go`.
💡 **Why:** `d.SetStrict(true)` and its associated comment `// SetStrict is not supported in v3.` were commented out and no longer useful, cluttering the code. This improves code readability.
✅ **Verification:** Ran `go test ./...` and `go fmt ./...`. Confirmed the fix involves only removing comments and does not change functionality.
✨ **Result:** Cleaner code in the `config` function.

---
*PR created automatically by Jules for task [12050238397951770334](https://jules.google.com/task/12050238397951770334) started by @filmil*