### PR TITLE
🧪 test: add error test for yaml config decode

### DIFF
--- a/pkg/opts/opts_test.go
+++ b/pkg/opts/opts_test.go
@@ -344,6 +344,16 @@ flags:
 `,
 			wantError: fmt.Errorf("not a string:"),
 		},
+		{
+			name: "Invalid YAML Decode",
+			args: []string{},
+			input: `
+flags:
+  - name: "foo"
+   type: string
+`,
+			wantError: fmt.Errorf("while decoding configuration:"),
+		},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing error test for config decode in `pkg/opts/opts.go`.
📊 **Coverage:** What scenarios are now tested: A test case with intentionally malformed YAML ensures that `config()` returns the correct error ("while decoding configuration:").
✨ **Result:** The improvement in test coverage: Increased confidence in the error handling logic during configuration loading, ensuring that decoding failures are caught and reported properly.

---
*PR created automatically by Jules for task [15509737868377871117](https://jules.google.com/task/15509737868377871117) started by @filmil*