### PR TITLE
🧪 test: add coverage for FTUnknown flag type in YAML parsing

### DIFF
--- a/pkg/opts/opts_test.go
+++ b/pkg/opts/opts_test.go
@@ -344,6 +344,18 @@ flags:
 `,
 			wantError: fmt.Errorf("not a string:"),
 		},
+		{
+			name: "Unknown flag type",
+			args: []string{},
+			input: `
+flags:
+- name: "foo"
+  type: "some_unknown_type"
+`,
+			expected: `# gotopt2:generated:begin
+# gotopt2:generated:end
+`,
+		},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing edge case test for `FTUnknown` in `UnmarshalYAML` within `pkg/opts/opts.go`.

📊 **Coverage:** A new scenario has been added where a flag configuration passes a non-existent flag type (e.g., `type: "some_unknown_type"`).

✨ **Result:** The improvement in test coverage guarantees that any unrecognized flag type is gracefully mapped to `FTUnknown`, and its subsequent processing safely bypasses bash code generation. Test tests and logic behavior are now fully verified.

---
*PR created automatically by Jules for task [4657532120936594076](https://jules.google.com/task/4657532120936594076) started by @filmil*