### PR TITLE
🧪 test: add missing error test for parseInt in opts package

### DIFF
--- a/pkg/opts/opts_test.go
+++ b/pkg/opts/opts_test.go
@@ -344,6 +344,17 @@ flags:
 `,
 			wantError: fmt.Errorf("not a string:"),
 		},
+		{
+			name: "ParseInt Error",
+			args: []string{},
+			input: `
+flags:
+- name: "foo"
+  type: int
+  default: "abc"
+`,
+			wantError: fmt.Errorf("flag: \"abc\": strconv.Atoi:"),
+		},
 	}
 	for _, test := range tests {
 		test := test


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing error test coverage for the `parseInt` function in `pkg/opts/opts.go`. The test is needed to verify that parsing an invalid integer from a YAML config correctly returns an error.

📊 **Coverage:** A new test scenario "ParseInt Error" has been added to the `TestGotopt2` table driven test suite. This scenario provides a configuration with an `int` type flag holding an invalid default string (`"abc"`). 

✨ **Result:** Test coverage in `pkg/opts` has been improved, and the test directly catches the expected error condition `fmt.Errorf("flag: \"abc\": strconv.Atoi:")` from the `parseInt` function.

---
*PR created automatically by Jules for task [688254093140937758](https://jules.google.com/task/688254093140937758) started by @filmil*