### PR TITLE
docs: add Comparison Matrix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,17 @@ at stdin? |
 
 # Q&A
 
+## Comparison Matrix
+
+Here is a quick overview of how `gotopt2` compares to `getopt` and `argbash`.
+
+| Feature | `getopt` | `argbash` | `gotopt2` |
+| :--- | :--- | :--- | :--- |
+| **Dependencies** | Target system `getopt` | `m4`, `make` | Self-contained Go binary |
+| **Configuration** | Arcane string flags | Inline bash comments | Simple YAML |
+| **Resulting Variables** | Unparsed string | Fully parsed bash variables | Fully parsed bash variables |
+| **Help Text Generation** | Manual | Auto-generated | Auto-generated |
+
 ## Why is it named gotopt2?
 
 I thought I was being original by riffing on the very well known name "getopt"

--- a/TODO.md
+++ b/TODO.md
@@ -33,4 +33,4 @@ Enhance the YAML configuration schema to support common CLI patterns.
 ## 5. Documentation & Examples
 - [ ] **Advanced Examples:** Add examples for using `gotopt2` with `local` variables in bash functions.
 - [ ] **Tutorial:** A "From Zero to Hero" guide in `docs/` or an expanded `README.md`.
-- [ ] **Comparison Matrix:** Explicitly show the differences between `getopt`, `argbash`, and `gotopt2`.
+- [x] **Comparison Matrix:** Explicitly show the differences between `getopt`, `argbash`, and `gotopt2`.


### PR DESCRIPTION
Added a new "Comparison Matrix" section to README.md under Q&A, and marked it as completed in TODO.md. This explicitly shows the differences and advantages of gotopt2 compared to getopt and argbash in terms of dependencies, configuration, output, and help text generation, addressing issue #102.

---
*PR created automatically by Jules for task [3525282679276787947](https://jules.google.com/task/3525282679276787947) started by @filmil*