### PR TITLE
docs: add comparison matrix for getopt, argbash, and gotopt2

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,18 @@ When `gotopt2` exits, it sets one of the following numerical error codes:
 at stdin? |
 | 142 | Any other error |
 
+# Comparison Matrix
+
+Here is a comparison between `getopt`, `argbash`, and `gotopt2` to help you decide which tool fits your needs.
+
+| Feature | `getopt` | `argbash` | `gotopt2` / `gotopt2-generator` |
+| --- | --- | --- | --- |
+| **Dependencies** | Requires `getopt` binary on target system (often different versions/behaviors across OSes). | Requires `m4` and a build step (e.g., `Makefile`). | Small, self-contained static binary (`gotopt2`) or zero-dependency shell script (`gotopt2-generator`). |
+| **Configuration** | Arcane and terse string syntax. | Specialized bash comments/macros. | Declarative, self-documenting YAML configuration. |
+| **Auto-generated Help** | No | Yes | Yes (both `gotopt2` and `gotopt2-generator`). |
+| **Parsing Effort** | You still need to write bash loops to parse the ordered output. | Fully generates the parsing logic. | Fully handles the parsing; you just `eval` the output or `source` the generated script. |
+| **Portability** | Inconsistent across platforms (e.g., macOS vs GNU Linux). | Build step can be complex in some environments; generated script is portable. | Binary is portable via simple container/install. Generator output is fully self-contained standard bash. |
+
 # Q&A
 
 ## Why is it named gotopt2?

--- a/TODO.md
+++ b/TODO.md
@@ -33,4 +33,4 @@ Enhance the YAML configuration schema to support common CLI patterns.
 ## 5. Documentation & Examples
 - [ ] **Advanced Examples:** Add examples for using `gotopt2` with `local` variables in bash functions.
 - [ ] **Tutorial:** A "From Zero to Hero" guide in `docs/` or an expanded `README.md`.
-- [ ] **Comparison Matrix:** Explicitly show the differences between `getopt`, `argbash`, and `gotopt2`.
+- [x] **Comparison Matrix:** Explicitly show the differences between `getopt`, `argbash`, and `gotopt2`.


### PR DESCRIPTION
Fixes https://github.com/filmil/gotopt2/issues/102

This PR adds a comparison matrix to the `README.md` to help users understand the benefits and differences between `gotopt2`, `getopt`, and `argbash`. 

It also checks off the corresponding box in the `TODO.md` file.

---
*PR created automatically by Jules for task [13276155822478169865](https://jules.google.com/task/13276155822478169865) started by @filmil*