### PR TITLE
refactor(opts): separate config parsing and flagset generation (#98)

### DIFF
--- a/cmd/gotopt2-generator/main.go
+++ b/cmd/gotopt2-generator/main.go
@@ -11,7 +11,6 @@ import (
 	"text/template"
 
 	"github.com/filmil/gotopt2/pkg/opts"
-	yaml "gopkg.in/yaml.v3"
 )
 
 //go:embed parser.sh.tmpl parser.fish.tmpl
@@ -47,10 +46,9 @@ type TemplateFlag struct {
 }
 
 func run(r io.Reader, shell string, w io.Writer) error {
-	d := yaml.NewDecoder(r)
-	var c opts.Config
-	if err := d.Decode(&c); err != nil {
-		return fmt.Errorf("decoding configuration: %v", err)
+	c, err := opts.ParseConfig(r)
+	if err != nil {
+		return err
 	}
 
 	return generateShell(c, w, shell)

--- a/pkg/opts/opts.go
+++ b/pkg/opts/opts.go
@@ -79,13 +79,13 @@ type Flag struct {
 // Run parses args based on a configuration supplied in r.  w gets all the
 // output.
 func Run(r io.Reader, args []string, w io.Writer) error {
-	c, err := config(r)
+	c, err := ParseConfig(r)
 	if err != nil {
 		return err
 	}
 
 	// Configure the flag set.
-	fs, err := flagSet(c)
+	fs, err := GenerateFlagSet(c)
 	if err != nil {
 		return err
 	}
@@ -157,7 +157,7 @@ func (s *StringListFlag) String() string {
 	return fmt.Sprintf("(%v)", strings.Join(q, " "))
 }
 
-func config(r io.Reader) (Config, error) {
+func ParseConfig(r io.Reader) (Config, error) {
 	d := yaml.NewDecoder(r)
 	var (
 		c   Config
@@ -170,7 +170,7 @@ func config(r io.Reader) (Config, error) {
 	return c, nil
 }
 
-func flagSet(c Config) (*flag.FlagSet, error) {
+func GenerateFlagSet(c Config) (*flag.FlagSet, error) {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 	for _, f := range c.Flags {
 		switch f.Type {


### PR DESCRIPTION
Addresses [Issue #98](https://github.com/filmil/gotopt2/issues/98) by refactoring the `pkg/opts` module.

Changes include:
*   Exporting `config` as `opts.ParseConfig`.
*   Exporting `flagSet` as `opts.GenerateFlagSet`.
*   Updating `opts.Run` to call the renamed functions.
*   Simplifying `cmd/gotopt2-generator/main.go` to use `opts.ParseConfig` directly, which deduplicates the YAML decoding logic.

All tests pass.

---
*PR created automatically by Jules for task [5825196978009536057](https://jules.google.com/task/5825196978009536057) started by @filmil*