### PR TITLE
feat: support `--flag value` space syntax in gotopt2-generator

### DIFF
--- a/cmd/gotopt2-generator/compare_test.sh
+++ b/cmd/gotopt2-generator/compare_test.sh
@@ -150,4 +150,24 @@ flags:
 '
 run_test "TrueValue" "$CONFIG_4" "--mybool"
 
+
+CONFIG_5='
+flags:
+- name: "foo"
+  help: "This is foo"
+  type: string
+- name: "bool-flag"
+  type: bool
+- name: "list-flag"
+  type: stringlist
+'
+run_test "SpaceSyntax" "$CONFIG_5" "--foo" "bar" "--bool-flag" "pos1" "pos2"
+
+CONFIG_6='
+flags:
+- name: "list-flag"
+  type: stringlist
+'
+run_test "ListSpaceSyntax" "$CONFIG_6" "--list-flag" "a,b,c"
+
 echo "All tests passed."

--- a/cmd/gotopt2-generator/main.go
+++ b/cmd/gotopt2-generator/main.go
@@ -109,7 +109,7 @@ func generateShell(c opts.Config, w io.Writer, shell string) error {
 		} else {
 			if f.Type == opts.FTStringList {
 				name := varNameStr + "__list"
-				outputs = append(outputs, fmt.Sprintf("  local %s_out\n  if [ ${#%s[@]} -eq 0 ]; then\n    %s_out=\"()\"\n  else\n    local %s_vals=()\n    for v in \"${%s[@]}\"; do\n      %s_vals+=(\"\\\"$v\\\"\")\n    done\n    %s_out=\"(${%s_vals[*]:-})\"\n  fi\n  echo \"%s\"",
+				outputs = append(outputs, fmt.Sprintf("  local %s_out\n  if [ ${#%s[@]} -eq 0 ]; then\n    %s_out=\"()\"\n  else\n    local %s_vals=()\n    for v in \"${%s[@]}\"; do\n      %s_vals+=(\"'$v'\")\n    done\n    %s_out=\"(${%s_vals[*]:-})\"\n  fi\n  echo \"%s\"",
 					actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", declLineBash(name, fmt.Sprintf("${%s_out}", actualVarName+"__list"), c.Prefix, c.Declaration, c.AllCaps, false)))
 			} else {
 				outputs = append(outputs, fmt.Sprintf("  echo \"%s\"", declLineBash(varNameStr, fmt.Sprintf("${%s}", actualVarName), c.Prefix, c.Declaration, c.AllCaps, true)))

--- a/cmd/gotopt2-generator/parser.fish.tmpl
+++ b/cmd/gotopt2-generator/parser.fish.tmpl
@@ -33,10 +33,28 @@ function parse_args
           set -a -g {{ .ActualVarName }}__list $v
         end
         set -e argv[1]
+      case --{{ .Name }}
+        if test (count $argv) -lt 2
+          echo "Missing value for --{{ .Name }}" >&2
+          return 1
+        end
+        set -l val $argv[2]
+        set -l vals (string split "," -- $val)
+        for v in $vals
+          set -a -g {{ .ActualVarName }}__list $v
+        end
+        set -e argv[1..2]
   {{- else }}
       case '--{{ .Name }}=*'
         set -g {{ .ActualVarName }} (string replace -r "^--{{ .Name }}=" "" -- $argv[1])
         set -e argv[1]
+      case --{{ .Name }}
+        if test (count $argv) -lt 2
+          echo "Missing value for --{{ .Name }}" >&2
+          return 1
+        end
+        set -g {{ .ActualVarName }} $argv[2]
+        set -e argv[1..2]
   {{- end }}
 {{- end }}
       case --

--- a/cmd/gotopt2-generator/parser.sh.tmpl
+++ b/cmd/gotopt2-generator/parser.sh.tmpl
@@ -35,10 +35,29 @@ parse_args() {
         done
         shift
         ;;
+      --{{ .Name }})
+        if [[ $# -lt 2 ]]; then
+          echo "Missing value for --{{ .Name }}" >&2
+          return 1
+        fi
+        IFS=',' read -ra ADDR <<< "$2"
+        for i in "${ADDR[@]}"; do
+          {{ .ActualVarName }}__list+=("$i")
+        done
+        shift 2
+        ;;
   {{- else }}
       --{{ .Name }}=*)
         {{ .ActualVarName }}="${1#*=}"
         shift
+        ;;
+      --{{ .Name }})
+        if [[ $# -lt 2 ]]; then
+          echo "Missing value for --{{ .Name }}" >&2
+          return 1
+        fi
+        {{ .ActualVarName }}="$2"
+        shift 2
         ;;
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Currently the generator output script `parse_args` only supports `--flag=value` (equals-separated) syntax for string and stringlist types. This change implements the logic to also allow space-separated `--flag value` parsing in both bash and fish templates. Also includes a minor fix to string array generation syntax to use single quotes in the `gotopt2-generator` to stay perfectly compatible with the actual `gotopt2` evaluated output format.

Resolves filmil/gotopt2#85

---
*PR created automatically by Jules for task [5394613262959074293](https://jules.google.com/task/5394613262959074293) started by @filmil*