### PR TITLE
fix(generator): Standardize stringlist parsing and fixing arg escaping

### DIFF
--- a/cmd/gotopt2-generator/compare_test.sh
+++ b/cmd/gotopt2-generator/compare_test.sh
@@ -151,3 +151,18 @@ flags:
 run_test "TrueValue" "$CONFIG_4" "--mybool"
 
 echo "All tests passed."
+
+CONFIG_5='
+flags:
+- name: "list"
+  type: stringlist
+'
+run_test "StringListEmpty" "$CONFIG_5" --list=""
+run_test "StringListSpaces" "$CONFIG_5" --list="a, b , c  "
+run_test "StringListTrailingComma" "$CONFIG_5" --list="a,b,"
+run_test "StringListQuotes" "$CONFIG_5" --list="a,'b',c"
+
+CONFIG_6='
+flags: []
+'
+run_test "ArgsQuotes" "$CONFIG_6" -- "it's"

--- a/cmd/gotopt2-generator/main.go
+++ b/cmd/gotopt2-generator/main.go
@@ -109,7 +109,7 @@ func generateShell(c opts.Config, w io.Writer, shell string) error {
 		} else {
 			if f.Type == opts.FTStringList {
 				name := varNameStr + "__list"
-				outputs = append(outputs, fmt.Sprintf("  local %s_out\n  if [ ${#%s[@]} -eq 0 ]; then\n    %s_out=\"()\"\n  else\n    local %s_vals=()\n    for v in \"${%s[@]}\"; do\n      %s_vals+=(\"\\\"$v\\\"\")\n    done\n    %s_out=\"(${%s_vals[*]:-})\"\n  fi\n  echo \"%s\"",
+				outputs = append(outputs, fmt.Sprintf("  local %s_out\n  if [ ${#%s[@]} -eq 0 ]; then\n    %s_out=\"()\"\n  else\n    local %s_vals=()\n    for v in \"${%s[@]}\"; do\n      %s_vals+=(\"'${v//\\'/\\'\\\"\\'\\\"\\'}'\")\n    done\n    %s_out=\"(${%s_vals[*]:-})\"\n  fi\n  echo \"%s\"",
 					actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", actualVarName+"__list", declLineBash(name, fmt.Sprintf("${%s_out}", actualVarName+"__list"), c.Prefix, c.Declaration, c.AllCaps, false)))
 			} else {
 				outputs = append(outputs, fmt.Sprintf("  echo \"%s\"", declLineBash(varNameStr, fmt.Sprintf("${%s}", actualVarName), c.Prefix, c.Declaration, c.AllCaps, true)))

--- a/cmd/gotopt2-generator/parser.fish.tmpl
+++ b/cmd/gotopt2-generator/parser.fish.tmpl
@@ -28,9 +28,11 @@ function parse_args
   {{- else if eq .Type 4 }}
       case '--{{ .Name }}=*'
         set -l val (string replace -r "^--{{ .Name }}=" "" -- $argv[1])
-        set -l vals (string split "," -- $val)
-        for v in $vals
-          set -a -g {{ .ActualVarName }}__list $v
+        if test -n "$val"
+          set -l vals (string split "," -- $val)
+          for v in $vals
+            set -a -g {{ .ActualVarName }}__list $v
+          end
         end
         set -e argv[1]
   {{- else }}

--- a/cmd/gotopt2-generator/parser.sh.tmpl
+++ b/cmd/gotopt2-generator/parser.sh.tmpl
@@ -29,10 +29,14 @@ parse_args() {
         ;;
   {{- else if eq .Type 4 }}
       --{{ .Name }}=*)
-        IFS=',' read -ra ADDR <<< "${1#*=}"
-        for i in "${ADDR[@]}"; do
-          {{ .ActualVarName }}__list+=("$i")
-        done
+        local val="${1#*=}"
+        if [ -n "$val" ]; then
+          while [[ "$val" == *","* ]]; do
+            {{ .ActualVarName }}__list+=("${val%%,*}")
+            val="${val#*,}"
+          done
+          {{ .ActualVarName }}__list+=("$val")
+        fi
         shift
         ;;
   {{- else }}
@@ -68,7 +72,7 @@ parse_args() {
   if [ ${#{{ .ArgsVarName }}[@]} -gt 0 ]; then
     local args_vals=()
     local arg_name="{{ .ArgsVarName }}"
-    eval "for v in \"\${${arg_name}[@]}\"; do args_vals+=(\"'\$v'\"); done"
+    eval "for v in \"\${${arg_name}[@]}\"; do v_esc=\"\${v//\\'/\\'\\\"\\'\\\"\\'}\"; args_vals+=(\"'\$v_esc'\"); done"
     local args_out="(${args_vals[*]:-})"
     echo "{{ .ArgsOutputDecl }}"
   fi


### PR DESCRIPTION
Fixes the `stringlist` empty array and trailing comma handling differences between the generated bash scripts and the gotopt2 Go executable. Implements correct quoting evaluation in `gotopt2-generator` for positional command line arguments and arrays.

Resolves #99

---
*PR created automatically by Jules for task [8506960246711398511](https://jules.google.com/task/8506960246711398511) started by @filmil*