### PR TITLE
fix: stop printing parsed variables to stdout in generator scripts

### DIFF
--- a/cmd/gotopt2-generator/compare_test.sh
+++ b/cmd/gotopt2-generator/compare_test.sh
@@ -52,21 +52,28 @@ run_test() {
          exit 1
       fi
   else
-      if ! diff -u "$out_gotopt2" "$out_generator"; then
-        echo "Outputs differ for test: $name"
+      local env_gotopt2="$TEMP_DIR/env_gotopt2_$name"
+      local env_generator="$TEMP_DIR/env_generator_$name"
+
+      # We ignore standard output from the generator, but we extract env vars
+      bash -c "source \"$out_gotopt2\"; declare -p | grep -E '(gotopt2_|my_prefix)' | grep -v BASH_EXECUTION_STRING | grep -v '_=' | sort" > "$env_gotopt2"
+      bash -c "source \"$parser_sh\"; parse_args \"\$@\"; declare -p | grep -E '(gotopt2_|my_prefix)' | grep -v BASH_EXECUTION_STRING | grep -v '_=' | sort" _ "${args[@]}" > "$env_generator"
+
+      if ! diff -u "$env_gotopt2" "$env_generator"; then
+        echo "Environment variables differ for test: $name"
         exit 1
       fi
   fi
 
   if command -v fish >/dev/null 2>&1; then
-      local out_generator_fish="$TEMP_DIR/out_generator_fish_$name"
       local err_generator_fish="$TEMP_DIR/err_generator_fish_$name"
       local parser_fish="$TEMP_DIR/parser_$name.fish"
 
       "$GENERATOR" --shell=fish < "$config_file" > "$parser_fish" 
 
       set +e
-      fish -c "source $parser_fish; parse_args \$argv" -- "${args[@]}" > "$out_generator_fish" 2> "$err_generator_fish"
+      # Run it once just to get exit code and stderr
+      fish -c "source $parser_fish; parse_args \$argv" -- "${args[@]}" > /dev/null 2> "$err_generator_fish"
       local generator_fish_exit=$?
       set -e
 
@@ -78,34 +85,16 @@ run_test() {
       fi
 
       if [[ "$name" != "Help" ]]; then
-          if ! grep -q "# gotopt2:generated:begin" "$out_generator_fish"; then
-              echo "Fish output missing generated block for test: $name"
-              exit 1
-          fi
-          # Test if evaluating the fish output succeeds
-          set +e
-          fish -c "cat $out_generator_fish | source"
-          local source_exit=$?
-          set -e
-          if [[ $source_exit -ne 0 ]]; then
-              echo "Failed to evaluate generated fish script for test: $name"
-              exit 1
-          fi
+          local env_gotopt2_fish="$TEMP_DIR/env_gotopt2_fish_$name"
+          local env_generator_fish="$TEMP_DIR/env_generator_fish_$name"
 
-          # Output verification: the generated code must have identical assignments.
-          # We extract the content between generated:begin and generated:end markers.
-          local bash_eval=$(sed -n '/# gotopt2:generated:begin/,/# gotopt2:generated:end/p' "$out_generator" | grep -v "# gotopt2:generated:")
-          local fish_eval=$(sed -n '/# gotopt2:generated:begin/,/# gotopt2:generated:end/p' "$out_generator_fish" | grep -v "# gotopt2:generated:")
+          # Convert bash variables from gotopt2 into fish vars
+          # (For testing we just check that the variable keys are populated similarly)
+          fish -c "cat $out_gotopt2 | source; set | grep -E '^(gotopt2_|my_prefix)' | sort" > "$env_gotopt2_fish"
+          fish -c "source $parser_fish; parse_args \$argv; set | grep -E '^(gotopt2_|my_prefix)' | sort" -- "${args[@]}" > "$env_generator_fish"
 
-          # Convert fish 'set -g VAR VAL' into bash 'VAR=VAL' format just for basic comparison of keys.
-          # Note: this might not handle complex quotes perfectly in bash format but verifies identical export names.
-          local fish_to_bash=$(echo "$fish_eval" | sed -r 's/set -g ([^ ]+) (.*)/\1=\2/')
-
-          # Just count the number of variables to ensure they map 1-1
-          local bash_lines=$(echo "$bash_eval" | grep -c "=" || true)
-          local fish_lines=$(echo "$fish_to_bash" | grep -c "=" || true)
-          if [[ $bash_lines -ne $fish_lines ]]; then
-              echo "Mismatch in number of variables generated. bash=$bash_lines, fish=$fish_lines"
+          if ! diff -u "$env_gotopt2_fish" "$env_generator_fish"; then
+              echo "Fish environment variables differ for test: $name"
               exit 1
           fi
       fi

--- a/cmd/gotopt2-generator/main.go
+++ b/cmd/gotopt2-generator/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
 	"strings"
 	"text/template"
 
@@ -30,10 +29,8 @@ func main() {
 }
 
 type TemplateData struct {
-	Flags          []TemplateFlag
-	ArgsVarName    string
-	SortedOutputs  []string
-	ArgsOutputDecl string
+	Flags       []TemplateFlag
+	ArgsVarName string
 }
 
 type TemplateFlag struct {
@@ -68,8 +65,6 @@ func generateShell(c opts.Config, w io.Writer, shell string) error {
 	data := TemplateData{
 		ArgsVarName: varName("args__", c.Prefix, c.AllCaps),
 	}
-
-	var outputs []string
 
 	trueVal := c.TrueValue
 	if trueVal == "" {
@@ -125,38 +120,6 @@ func generateShell(c opts.Config, w io.Writer, shell string) error {
 	}
 
 	return tmpl.Execute(w, data)
-}
-
-func declLineFish(name, value, prefix string, toUpper, quote bool) string {
-	r := strings.NewReplacer("-", "_")
-	name = r.Replace(name)
-	fullVarName := fmt.Sprintf("%sgotopt2_%s", prefix, name)
-	if toUpper {
-		fullVarName = strings.ToUpper(fullVarName)
-	}
-	if quote {
-		assignment := fmt.Sprintf("set -g %s '%s'", fullVarName, value)
-		return assignment
-	}
-	assignment := fmt.Sprintf("set -g %s %s", fullVarName, value)
-	return assignment
-}
-
-func declLineBash(name, value, prefix, decl string, toUpper, quote bool) string {
-	r := strings.NewReplacer("-", "_")
-	name = r.Replace(name)
-	fullVarName := fmt.Sprintf("%sgotopt2_%s", prefix, name)
-	if toUpper {
-		fullVarName = strings.ToUpper(fullVarName)
-	}
-	assignment := fmt.Sprintf("%s='%s'", fullVarName, value)
-	if !quote {
-		assignment = fmt.Sprintf("%s=%s", fullVarName, value)
-	}
-	if decl == "" {
-		return assignment
-	}
-	return strings.Join([]string{decl, assignment}, " ")
 }
 
 func varName(name, prefix string, allCaps bool) string {

--- a/cmd/gotopt2-generator/parser.fish.tmpl
+++ b/cmd/gotopt2-generator/parser.fish.tmpl
@@ -73,18 +73,4 @@ function parse_args
     end
   end
 
-  echo "# gotopt2:generated:begin"
-{{- range .SortedOutputs }}
-  {{ . }}
-{{- end }}
-  if test (count ${{ .ArgsVarName }}) -gt 0
-    set -l args_vals
-    for v in ${{ .ArgsVarName }}
-      set -l esc (string replace -a "'" "\\'" "$v")
-      set -a args_vals "'$esc'"
-    end
-    set -l args_out (string join " " $args_vals)
-    echo "{{ .ArgsOutputDecl }}"
-  end
-  echo "# gotopt2:generated:end"
 end

--- a/cmd/gotopt2-generator/parser.sh.tmpl
+++ b/cmd/gotopt2-generator/parser.sh.tmpl
@@ -80,17 +80,5 @@ parse_args() {
     esac
   done
 
-  echo "# gotopt2:generated:begin"
-{{- range .SortedOutputs }}
-  {{ . }}
-{{- end }}
-  if [ ${#{{ .ArgsVarName }}[@]} -gt 0 ]; then
-    local args_vals=()
-    local arg_name="{{ .ArgsVarName }}"
-    eval "for v in \"\${${arg_name}[@]}\"; do args_vals+=(\"'\$v'\"); done"
-    local args_out="(${args_vals[*]:-})"
-    echo "{{ .ArgsOutputDecl }}"
-  fi
-  echo "# gotopt2:generated:end"
 }
 {{/* We want to support --help */}}


### PR DESCRIPTION
Summary of changes:
- Removed obsolete code that appended generated variables to the output array.
- Stopped printing variables to stdout in fish and bash generator templates.
- Fixed the `compare_test.sh` script to correctly verify environment variable generation.

Fixes: https://github.com/filmil/gotopt2/pull/117

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt: in a new git worktree, with ../ as worktree base dir, take https://github.com/filmil/gotopt2/pull/117 and fix it