### PR TITLE
feat: Add custom usage string to config for `--help`

### DIFF
--- a/cmd/gotopt2-generator/compare_test.sh
+++ b/cmd/gotopt2-generator/compare_test.sh
@@ -40,7 +40,7 @@ run_test() {
       exit 1
   fi
 
-  if [[ "$name" == "Help" ]]; then
+  if [[ "$name" == "Help" || "$name" == "HelpUsage" ]]; then
       # Help output to stderr might be slightly different stylistically, 
       # but we can check if both exited 11 and printed something.
       if [[ $gotopt2_exit -ne 11 ]]; then
@@ -50,6 +50,16 @@ run_test() {
       if ! grep -q "Usage" "$err_generator"; then
          echo "generator didn't print usage!"
          exit 1
+      fi
+      if [[ "$name" == "HelpUsage" ]]; then
+          if ! grep -q "Custom generator usage" "$err_generator"; then
+             echo "generator didn't print custom usage!"
+             exit 1
+          fi
+          if ! grep -q "Custom generator usage" "$err_gotopt2"; then
+             echo "gotopt2 didn't print custom usage!"
+             exit 1
+          fi
       fi
   else
       if ! diff -u "$out_gotopt2" "$out_generator"; then
@@ -77,7 +87,7 @@ run_test() {
           exit 1
       fi
 
-      if [[ "$name" != "Help" ]]; then
+      if [[ "$name" != "Help" && "$name" != "HelpUsage" ]]; then
           if ! grep -q "# gotopt2:generated:begin" "$out_generator_fish"; then
               echo "Fish output missing generated block for test: $name"
               exit 1
@@ -141,6 +151,15 @@ flags:
   help: "Foo configuration"
 '
 run_test "Help" "$CONFIG_3" "--help"
+
+CONFIG_3_5='
+usage: "Custom generator usage"
+flags:
+- name: "foo"
+  type: string
+  help: "Foo configuration"
+'
+run_test "HelpUsage" "$CONFIG_3_5" "--help"
 
 CONFIG_4='
 trueValue: "on"

--- a/cmd/gotopt2-generator/main.go
+++ b/cmd/gotopt2-generator/main.go
@@ -34,6 +34,7 @@ type TemplateData struct {
 	ArgsVarName    string
 	SortedOutputs  []string
 	ArgsOutputDecl string
+	Usage          string
 }
 
 type TemplateFlag struct {
@@ -67,6 +68,7 @@ func generateShell(c opts.Config, w io.Writer, shell string) error {
 
 	data := TemplateData{
 		ArgsVarName: varName("args__", c.Prefix, c.AllCaps),
+		Usage:       c.Usage,
 	}
 
 	var outputs []string

--- a/cmd/gotopt2-generator/parser.fish.tmpl
+++ b/cmd/gotopt2-generator/parser.fish.tmpl
@@ -14,6 +14,10 @@ function parse_args
   while test (count $argv) -gt 0
     switch $argv[1]
       case --help
+{{- if .Usage }}
+        echo "{{ .Usage }}" >&2
+        echo >&2
+{{- end }}
         echo "Usage:" >&2
 {{- range .Flags }}
         echo "  --{{ .Name }}" >&2

--- a/cmd/gotopt2-generator/parser.sh.tmpl
+++ b/cmd/gotopt2-generator/parser.sh.tmpl
@@ -14,6 +14,10 @@ parse_args() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --help)
+{{- if .Usage }}
+        echo "{{ .Usage }}" >&2
+        echo >&2
+{{- end }}
         echo "Usage:" >&2
 {{- range .Flags }}
         echo "  --{{ .Name }}" >&2

--- a/cmd/gotopt2/gotopt2_test.bats
+++ b/cmd/gotopt2/gotopt2_test.bats
@@ -44,6 +44,29 @@ EOF
   [ "${#lines[@]}" -eq 4 ]
 }
 
+@test "Usage printing with usage text" {
+  run "${GOTOPT2}" --unknown <<EOF
+usage: "This is a custom usage text."
+flags:
+- name: "foo"
+  type: string
+  default: "nothing"
+  help: "This is some flag value."
+EOF
+  echo "${status}"
+  echo "${lines[0]}"
+  echo "${lines[1]}"
+  echo "${lines[2]}"
+  echo "${lines[3]}"
+  echo "${lines[4]}"
+  echo "${lines[5]}"
+  [ "${status}" -eq 142 ] # The exit code is randomly set to 142
+  [ "${lines[0]}" == "flag provided but not defined: -unknown" ]
+  [ "${lines[1]}" == "This is a custom usage text." ]
+  [ "${lines[2]}" == "Usage:" ]
+  [ "${lines[3]}" == "  -foo string" ]
+}
+
 @test "Stringlist printing" {
   run "${GOTOPT2}" --list=eenie,meenie,minie,moe <<EOF
 flags:

--- a/pkg/opts/opts.go
+++ b/pkg/opts/opts.go
@@ -32,6 +32,8 @@ type Config struct {
 	// Declaration is the default declaration word to use.  For example
 	// "readonly" or "local".
 	Declaration string `yaml:"declaration"`
+	// Usage provides a description for the command usage.
+	Usage string `yaml:"usage"`
 }
 
 // FType is the type of the flag variable
@@ -172,6 +174,13 @@ func ParseConfig(r io.Reader) (Config, error) {
 
 func GenerateFlagSet(c Config) (*flag.FlagSet, error) {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	fs.Usage = func() {
+		if c.Usage != "" {
+			fmt.Fprintf(fs.Output(), "%s\n\n", c.Usage)
+		}
+		fmt.Fprintf(fs.Output(), "Usage:\n")
+		fs.PrintDefaults()
+	}
 	for _, f := range c.Flags {
 		switch f.Type {
 		case FTString:

--- a/pkg/opts/opts_test.go
+++ b/pkg/opts/opts_test.go
@@ -59,6 +59,17 @@ flags:
 			wantError: flag.ErrHelp,
 		},
 		{
+			name: "Help with Usage",
+			args: []string{"--help"},
+			input: `
+usage: "This is a custom usage string"
+flags:
+- name: "foo"
+  type: string
+`,
+			wantError: flag.ErrHelp,
+		},
+		{
 			name: "String list",
 			args: []string{"-foo=bar,baz,bat", "arg"},
 			input: `


### PR DESCRIPTION
This PR adds support for a custom `usage` string in the YAML configuration, as requested in issue #113. 

When the `usage` key is provided in the configuration, its value is printed before the flags list when `--help` is invoked (or an unknown flag is provided). The functionality is implemented for both the `gotopt2` binary and the `gotopt2-generator` tool (for both `bash` and `fish` output formats). Tests have been added to verify correct generation and execution in all supported flows.

---
*PR created automatically by Jules for task [2095603917635131339](https://jules.google.com/task/2095603917635131339) started by @filmil*