### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection in gotopt2-generator

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** Command injection was possible because `gotopt2` output bash variables without sanitizing the `name`, `prefix`, and `declaration` configuration inputs. An attacker could inject arbitrary commands by providing values like `foo;echo INJECTED`.
 **Learning:** Even configurable prefixes and variable names can be vectors for command injection if the output is evaluated (`eval`). Unsanitized configuration strings can break out of variable assignment contexts.
 **Prevention:** Strictly sanitize all variables, prefixes, and declarations using an allowlist approach to ensure only valid Bash identifier characters (`[a-zA-Z0-9_]`) or specific declaration characters (`[a-zA-Z0-9_ \-]`) are emitted into shell scripts.
+## 2025-02-05 - [Command Injection via Configuration Parameters in gotopt2-generator]
+**Vulnerability:** Command injection was possible because `gotopt2-generator` output bash scripts without sanitizing the `name` and `prefix` configuration inputs. An attacker could inject arbitrary commands directly into the generated script by providing values like `evil;echo INJECTED`.
+**Learning:** Configurable prefixes and variable names can be vectors for command injection if the output is evaluated or sourced as a script. Unsanitized configuration strings can break out of variable assignment contexts in the generated file.
+**Prevention:** Strictly sanitize all variables, prefixes, and declarations using an allowlist approach to ensure only valid Bash identifier characters (`[a-zA-Z0-9_]`) are emitted into shell scripts.

--- a/cmd/gotopt2-generator/main.go
+++ b/cmd/gotopt2-generator/main.go
@@ -100,6 +100,8 @@ func generateShell(c opts.Config, w io.Writer, shell string) error {
 func varName(name, prefix string, allCaps bool) string {
 	r := strings.NewReplacer("-", "_")
 	name = r.Replace(name)
+	name = opts.SanitizeBashIdentifier(name)
+	prefix = opts.SanitizeBashIdentifier(prefix)
 	fullVarName := fmt.Sprintf("%sgotopt2_%s", prefix, name)
 	if allCaps {
 		fullVarName = strings.ToUpper(fullVarName)

--- a/pkg/opts/opts.go
+++ b/pkg/opts/opts.go
@@ -214,7 +214,8 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
-func sanitizeBashIdentifier(s string) string {
+// SanitizeBashIdentifier ensures a string contains only valid characters for bash variables
+func SanitizeBashIdentifier(s string) string {
 	var sb strings.Builder
 	for _, r := range s {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
@@ -237,8 +238,8 @@ func sanitizeBashDecl(s string) string {
 func declLine(name, value, prefix, decl string, toUpper, quote bool) string {
 	r := strings.NewReplacer("-", "_")
 	name = r.Replace(name)
-	name = sanitizeBashIdentifier(name)
-	prefix = sanitizeBashIdentifier(prefix)
+	name = SanitizeBashIdentifier(name)
+	prefix = SanitizeBashIdentifier(prefix)
 	decl = sanitizeBashDecl(decl)
 	fullVarName := fmt.Sprintf("%vgotopt2_%v", prefix, name)
 	if toUpper {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command injection in `gotopt2-generator` via unsanitized `prefix` and `name` strings. If evaluated or sourced, it could allow arbitrary command execution.
🎯 Impact: Attackers controlling configuration can inject commands directly into generated bash scripts.
🔧 Fix: Exported `SanitizeBashIdentifier` and wrapped user-controlled inputs in `varName` during generation.
✅ Verification: Ran `bazel test //...` which passed. Created local payload tests ensuring `evil;echo INJECTED#` gets correctly stripped in resulting output scripts.

---
*PR created automatically by Jules for task [9309418100191149908](https://jules.google.com/task/9309418100191149908) started by @filmil*