### PR TITLE
🧹 [Code Health] Refactor duplicate bash sanitization logic

### DIFF
--- a/pkg/opts/opts.go
+++ b/pkg/opts/opts.go
@@ -214,25 +214,23 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
-// SanitizeBashIdentifier ensures a string contains only valid characters for bash variables
-func SanitizeBashIdentifier(s string) string {
+func sanitize(s string, allowDashAndSpace bool) string {
 	var sb strings.Builder
 	for _, r := range s {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || (allowDashAndSpace && (r == '-' || r == ' ')) {
 			sb.WriteRune(r)
 		}
 	}
 	return sb.String()
 }
 
+// SanitizeBashIdentifier ensures a string contains only valid characters for bash variables
+func SanitizeBashIdentifier(s string) string {
+	return sanitize(s, false)
+}
+
 func sanitizeBashDecl(s string) string {
-	var sb strings.Builder
-	for _, r := range s {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' || r == ' ' {
-			sb.WriteRune(r)
-		}
-	}
-	return sb.String()
+	return sanitize(s, true)
 }
 
 func declLine(name, value, prefix, decl string, toUpper, quote bool) string {


### PR DESCRIPTION
🎯 **What:** Extracted duplicate rune-iteration logic from `SanitizeBashIdentifier` and `sanitizeBashDecl` into a single helper function `sanitize(s string, allowDashAndSpace bool) string`.
💡 **Why:** Reduces code duplication, making future modifications to validation logic less prone to errors or mismatches.
✅ **Verification:** Verified by running `go test ./...` and `cmd/gotopt2-generator/compare_test.sh`, which compare output parity of the generated bash parser before and after the change. Both exit successfully, demonstrating zero regressions. Unrelated `MODULE.bazel.lock` modifications caused by local tooling were specifically restored.
✨ **Result:** Improved codebase readability and maintainability without altering functionality.

---
*PR created automatically by Jules for task [16365559968620298431](https://jules.google.com/task/16365559968620298431) started by @filmil*