### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,8 +3,8 @@ module(
     version = "2.0.1",
 )
 
-bazel_dep(name = "rules_go", version = "0.60.0")
-bazel_dep(name = "gazelle", version = "0.51.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "rules_go", version = "0.61.1")
+bazel_dep(name = "gazelle", version = "0.51.3", repo_name = "bazel_gazelle")
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
 bazel_dep(name = "bazel_bats", version = "0.38.23")
 bazel_dep(name = "rules_pkg", version = "1.2.0")
@@ -39,4 +39,4 @@ bazel_dep(name = "bazel_lib", version = "3.3.1")
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.9.0")
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "stardoc", version = "0.8.1")
-bazel_dep(name = "protobuf", version = "35.0")
+bazel_dep(name = "protobuf", version = "35.1")


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_go: 0.60.0 -> 0.61.1
* gazelle: 0.51.0 -> 0.51.3
* protobuf: 35.0 -> 35.1