### PR TITLE
fix: skip the release and the publication when nothing changed

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -44,24 +44,35 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: main
+          # Without this the action bumps the patch version on every run, even
+          # when no commit landed since the last tag. The cron then released the
+          # same tree again and again. `false` makes the action emit an empty
+          # `new_tag` when no commit asks for a release, and the guards below
+          # then skip the release and the publication.
+          default_bump: false
       - name: Create a GitHub release
+        if: ${{ steps.tag_version.outputs.new_tag != '' }}
         uses: ncipollo/release-action@v1.21.0
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           generateReleaseNotes: true
       - name: Get release tag
+        if: ${{ steps.tag_version.outputs.new_tag != '' }}
         id: get_version
         run: echo "VERSION=${{ steps.tag_version.outputs.new_tag }}" >> $GITHUB_ENV
       - name: Get repo name
+        if: ${{ steps.tag_version.outputs.new_tag != '' }}
         id: get_repo_name
         run: echo "REPO_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
       - name: "Publish source archive"
+        if: ${{ steps.tag_version.outputs.new_tag != '' }}
         uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'zip'
           filename: "${{ env.REPO_NAME }}-${{ env.VERSION }}.zip"
           exclusions: '*.git* /*node_modules/* .editorconfig /bazel-*'
       - name: "Upload source archive"
+        if: ${{ steps.tag_version.outputs.new_tag != '' }}
         uses: ncipollo/release-action@v1.21.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -72,6 +83,7 @@ jobs:
 
   release:
     needs: tag
+    if: ${{ needs.tag.outputs.tag_name != '' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -112,6 +124,7 @@ jobs:
 
   publish:
     needs: [tag, release]
+    if: ${{ needs.tag.outputs.tag_name != '' }}
     uses: ./.github/workflows/publish.yml
     with:
       tag_name: ${{ needs.tag.outputs.tag_name }}


### PR DESCRIPTION
## The problem

The cron releases the same tree over and over. `git rev-list --count v2.8.9..v2.8.10` returns 0. The last two tags hold
the same tree.

The cause is `mathieudutour/github-tag-action`. Its `default_bump` input
defaults to `patch`. The action therefore bumps the version on every run, even
when no commit landed since the last tag. Each empty bump then made a GitHub
release and opened a pull request against the registry.

This is not a local problem. 31 of your 34 repositories with two or more tags
have zero commits between their last two tags.

## The change

This copies the pattern that `rules_shar` and `bazel_rootfs` already use, and
matches the three pull requests you merged in `bazel_rules_latex_host`,
`lit2md` and `bazel_graphviz`:

* `default_bump: false` makes the action emit an empty `new_tag` when no commit
  asks for a release.
* Each release step in the `tag` job now runs only when `new_tag` is not empty.
* The `release` job now runs only when `tag_name` is not empty.
* The `publish` job now runs only when `tag_name` is not empty.

## What changes for you

A commit title must follow conventional commits (`fix:`, `feat:` or
`BREAKING:`) to cause a release. A plain title produces no release. The SOP
requires that style already, so the two agree.

When nothing changed, the workflow still runs the build and the tests, finds no
reason to release, and stops. It makes no tag, no release and no registry pull
request.

## Summary of commits

* `fix: skip the release and the publication when nothing changed` — edits
  `.github/workflows/tag-and-release.yml` only. 1 file changed.

## Verification

A script made this edit, and the same script reproduced, character for
character, the three edits you already reviewed and merged. It also left
`rules_shar` and `bazel_rootfs` untouched, which are already correct.

I then parsed the result with `yaml.safe_load` and checked that `default_bump`
is `false`, that no release step is left unguarded, and that each job guard
names the output the `tag` job actually declares.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt used to generate this pull request:

  when done: check all my GitHub repos, and if any have defined BCR and private registry publication workflows, send PRs to modify workflows to *skip* publication if no changes
